### PR TITLE
Although the return of getRequest() is defined...

### DIFF
--- a/Yaf/Controller_Abstract.php
+++ b/Yaf/Controller_Abstract.php
@@ -74,7 +74,7 @@ abstract class Controller_Abstract {
 	 *
 	 * @link http://www.php.net/manual/en/yaf-controller-abstract.getrequest.php
 	 *
-	 * @return \Yaf\Request_Abstract
+	 * @return \Yaf\Request_Abstract|\Yaf\Request\Simple|\Yaf\Request\Http
 	 */
 	public function getRequest(){ }
 

--- a/Yaf/Dispatcher.php
+++ b/Yaf/Dispatcher.php
@@ -142,7 +142,7 @@ final class Dispatcher {
 	/**
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.getrequest.php
 	 *
-	 * @return \Yaf\Request_Abstract
+	 * @return \Yaf\Request_Abstract|\Yaf\Request\Simple|\Yaf\Request\Http
 	 */
 	public function getRequest(){ }
 

--- a/yaf.php
+++ b/yaf.php
@@ -390,7 +390,7 @@ final class Yaf_Dispatcher {
 	/**
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.getrequest.php
 	 *
-	 * @return Yaf_Request_Abstract
+	 * @return Yaf_Request_Abstract|Yaf_Request_Simple|Yaf_Request_Http
 	 */
 	public function getRequest(){ }
 
@@ -1084,7 +1084,7 @@ abstract class Yaf_Controller_Abstract {
 	 *
 	 * @link http://www.php.net/manual/en/yaf-controller-abstract.getrequest.php
 	 *
-	 * @return Yaf_Request_Abstract
+	 * @return Yaf_Request_Abstract|Yaf_Request_Simple|Yaf_Request_Http
 	 */
 	public function getRequest(){ }
 


### PR DESCRIPTION
Although the return of getRequest() is defined as Yaf_Request_Abstract, but it may be Yaf_Request_Http or Yaf_Request_Simple in actual use.

Changing the return to all these three type will provide better code auto-completing experience, e.g. $this->getRequest()->getPost()