### PR TITLE
It's a bug in generate_namespace.php

### DIFF
--- a/Yaf/Application.php
+++ b/Yaf/Application.php
@@ -118,7 +118,7 @@ final class Application {
 	public function execute(callable $entry, $_ = "..."){ }
 
 	/**
-	 * Retrieve the \Yaf\Application instance, alternatively, we also could use\Yaf\Dispatcher::getApplication().
+	 * Retrieve the \Yaf\Application instance, alternatively, we also could use \Yaf\Dispatcher::getApplication().
 	 *
 	 * @link http://www.php.net/manual/en/yaf-application.app.php
 	 *

--- a/Yaf/Application.php
+++ b/Yaf/Application.php
@@ -18,11 +18,11 @@ final class Application {
 	 */
 	protected static $_app;
 	/**
-	 * @var\Yaf\Config_Abstract
+	 * @var \Yaf\Config_Abstract
 	 */
 	protected $config;
 	/**
-	 * @var\Yaf\Dispatcher
+	 * @var \Yaf\Dispatcher
 	 */
 	protected $dispatcher;
 	/**
@@ -93,7 +93,7 @@ final class Application {
 	 * </p>
 	 * @param string $envrion Which section will be loaded as the final config
 	 *
-	 * @throws\Yaf\Exception\TypeError|\Yaf\Exception\StartupError
+	 * @throws \Yaf\Exception\TypeError|\Yaf\Exception\StartupError
 	 */
 	public function __construct($config, $envrion = null){ }
 
@@ -102,7 +102,7 @@ final class Application {
 	 * return response to client finally.
 	 *
 	 * @link http://www.php.net/manual/en/yaf-application.run.php
-	 * @throws\Yaf\Exception\StartupError
+	 * @throws \Yaf\Exception\StartupError
 	 */
 	public function run(){ }
 
@@ -148,7 +148,7 @@ final class Application {
 	/**
 	 * @link http://www.php.net/manual/en/yaf-application.getconfig.php
 	 *
-	 * @return\Yaf\Config_Abstract
+	 * @return \Yaf\Config_Abstract
 	 */
 	public function getConfig(){ }
 
@@ -164,7 +164,7 @@ final class Application {
 	/**
 	 * @link http://www.php.net/manual/en/yaf-application.getdispatcher.php
 	 *
-	 * @return\Yaf\Dispatcher
+	 * @return \Yaf\Dispatcher
 	 */
 	public function getDispatcher(){ }
 

--- a/Yaf/Bootstrap_Abstract.php
+++ b/Yaf/Bootstrap_Abstract.php
@@ -4,7 +4,7 @@ namespace Yaf ;
 /**
  * <p>Bootstrap is a mechanism used to do some initial config before a Application run.<br/><br/></p>
  * <p>User may define their own Bootstrap class by inheriting <b>\Yaf\Bootstrap_Abstract</b><br/><br/></p>
- * <p>Any method declared in Bootstrap class with leading "_init", will be called by\Yaf\Application::bootstrap() one by one according to their defined order<br/><br/></p>
+ * <p>Any method declared in Bootstrap class with leading "_init", will be called by \Yaf\Application::bootstrap() one by one according to their defined order<br/><br/></p>
  *
  * @link http://www.php.net/manual/en/class.yaf-bootstrap-abstract.php
  */

--- a/Yaf/Config/Ini.php
+++ b/Yaf/Config/Ini.php
@@ -46,7 +46,7 @@ class Ini extends \Yaf\Config_Abstract implements \Iterator, \Traversable, \Arra
 	 * @param string $config_file path to an INI configure file
 	 * @param string $section which section in that INI file you want to be parsed
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	public function __construct($config_file, $section = null){ }
 

--- a/Yaf/Controller_Abstract.php
+++ b/Yaf/Controller_Abstract.php
@@ -10,7 +10,7 @@ namespace Yaf ;
  * <br/>
  * <p>If you have defined a init() method in your custom controller, it will be called as long as the controller was instantiated.</p>
  * <br/>
- * <p>Action may have arguments, when a request coming, if there are the same name variable in the request parameters(see \Yaf\Request_Abstract::getParam()) after routed, Yaf will pass them to the action method (see\Yaf\Action_Abstract::execute()).</p>
+ * <p>Action may have arguments, when a request coming, if there are the same name variable in the request parameters(see \Yaf\Request_Abstract::getParam()) after routed, Yaf will pass them to the action method (see \Yaf\Action_Abstract::execute()).</p>
  * <br/>
  * <b>Note:</b>
  * <p>These arguments are directly fetched without filtering, it should be carefully processed before use them.</p>
@@ -20,8 +20,8 @@ namespace Yaf ;
 abstract class Controller_Abstract {
 
 	/**
-	 * @see\Yaf\Action_Abstract
-	 * @var array You can also define a action method in a separate PHP script by using this property and\Yaf\Action_Abstract.
+	 * @see \Yaf\Action_Abstract
+	 * @var array You can also define a action method in a separate PHP script by using this property and \Yaf\Action_Abstract.
 	 */
 	public $actions;
 	/**

--- a/Yaf/Dispatcher.php
+++ b/Yaf/Dispatcher.php
@@ -14,7 +14,7 @@ final class Dispatcher {
 	 */
 	protected static $_instance;
 	/**
-	 * @var\Yaf\Router
+	 * @var \Yaf\Router
 	 */
 	protected $_router;
 	/**
@@ -106,7 +106,7 @@ final class Dispatcher {
 	public function initView($templates_dir, array $options = null){ }
 
 	/**
-	 * This method provides a solution for that if you want use a custom view engine instead of\Yaf\View\Simple
+	 * This method provides a solution for that if you want use a custom view engine instead of \Yaf\View\Simple
 	 *
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.setview.php
 	 *
@@ -125,17 +125,17 @@ final class Dispatcher {
 	public function setRequest(\Yaf\Request_Abstract $request){ }
 
 	/**
-	 * Retrieve the\Yaf\Application instance. same as\Yaf\Application::app().
+	 * Retrieve the \Yaf\Application instance. same as \Yaf\Application::app().
 	 *
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.getapplication.php
-	 * @return\Yaf\Application
+	 * @return \Yaf\Application
 	 */
 	public function getApplication(){ }
 
 	/**
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.getrouter.php
 	 *
-	 * @return\Yaf\Router
+	 * @return \Yaf\Router
 	 */
 	public function getRouter(){ }
 
@@ -240,14 +240,14 @@ final class Dispatcher {
 	 *
 	 * @param \Yaf\Request_Abstract $request
 	 *
-	 * @throws\Yaf\Exception\TypeError
-	 * @throws\Yaf\Exception\RouterFailed
-	 * @throws\Yaf\Exception\DispatchFailed
-	 * @throws\Yaf\Exception\LoadFailed
-	 * @throws\Yaf\Exception\LoadFailed\Action
-	 * @throws\Yaf\Exception\LoadFailed\Controller
+	 * @throws \Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\RouterFailed
+	 * @throws \Yaf\Exception\DispatchFailed
+	 * @throws \Yaf\Exception\LoadFailed
+	 * @throws \Yaf\Exception\LoadFailed\Action
+	 * @throws \Yaf\Exception\LoadFailed\Controller
 	 *
-	 * @return\Yaf\Response_Abstract
+	 * @return \Yaf\Response_Abstract
 	 */
 	public function dispatch(\Yaf\Request_Abstract $request){ }
 
@@ -263,8 +263,8 @@ final class Dispatcher {
 	public function throwException($flag = null){ }
 
 	/**
-	 * <p>While the application.dispatcher.throwException is On(you can also calling to <b>\Yaf\Dispatcher::throwException(TRUE)</b> to enable it), Yaf will throw\Exception whe error occurs instead of trigger error.</p><br/>
-	 * <p>then if you enable <b>\Yaf\Dispatcher::catchException()</b>(also can enabled by set application.dispatcher.catchException), all uncaught\Exceptions will be caught by ErrorController::error if you have defined one.</p>
+	 * <p>While the application.dispatcher.throwException is On(you can also calling to <b>\Yaf\Dispatcher::throwException(TRUE)</b> to enable it), Yaf will throw \Exception whe error occurs instead of trigger error.</p><br/>
+	 * <p>then if you enable <b>\Yaf\Dispatcher::catchException()</b>(also can enabled by set application.dispatcher.catchException), all uncaught \Exceptions will be caught by ErrorController::error if you have defined one.</p>
 	 *
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.catchexception.php
 	 *
@@ -274,7 +274,7 @@ final class Dispatcher {
 	public function catchException($flag = null){ }
 
 	/**
-	 * Register a plugin(see \Yaf\Plugin_Abstract). Generally, we register plugins in Bootstrap(see\Yaf\Bootstrap_Abstract).
+	 * Register a plugin(see \Yaf\Plugin_Abstract). Generally, we register plugins in Bootstrap(see \Yaf\Bootstrap_Abstract).
 	 *
 	 * @link http://www.php.net/manual/en/yaf-dispatcher.registerplugin.php
 	 *

--- a/Yaf/Loader.php
+++ b/Yaf/Loader.php
@@ -4,7 +4,7 @@ namespace Yaf ;
 /**
  * <p><b>\Yaf\Loader</b> introduces a comprehensive autoloading solution for Yaf.</p>
  * <br/>
- * <p>The first time an instance of\Yaf\Application is retrieved, <b>\Yaf\Loader</b> will instance a singleton, and registers itself with spl_autoload. You retrieve an instance using the \Yaf\Loader::getInstance()</p>
+ * <p>The first time an instance of \Yaf\Application is retrieved, <b>\Yaf\Loader</b> will instance a singleton, and registers itself with spl_autoload. You retrieve an instance using the \Yaf\Loader::getInstance()</p>
  * <br/>
  * <p><b>\Yaf\Loader</b> attempt to load a class only one shot, if failed, depend on yaf.use_spl_autoload, if this config is On \Yaf\Loader::autoload() will return FALSE, thus give the chance to other autoload function. if it is Off (by default), \Yaf\Loader::autoload() will return TRUE, and more important is that a very useful warning will be triggered (very useful to find out why a class could not be loaded).</p>
  * <br/>

--- a/Yaf/Plugin_Abstract.php
+++ b/Yaf/Plugin_Abstract.php
@@ -6,7 +6,7 @@ namespace Yaf ;
  * <br/>
  * <p>Plugins are classes. The actual class definition will vary based on the component -- you may need to implement this interface, but the fact remains that the plugin is itself a class.</p>
  * <br/>
- * <p>A plugin could be loaded into Yaf by using\Yaf\Dispatcher::registerPlugin(), after registered, All the methods which the plugin implemented according to this interface, will be called at the proper time.</p>
+ * <p>A plugin could be loaded into Yaf by using \Yaf\Dispatcher::registerPlugin(), after registered, All the methods which the plugin implemented according to this interface, will be called at the proper time.</p>
  * @link http://www.php.net/manual/en/class.yaf-plugin-abstract.php
  */
 abstract class Plugin_Abstract {

--- a/Yaf/Request/Simple.php
+++ b/Yaf/Request/Simple.php
@@ -97,7 +97,7 @@ class Simple extends \Yaf\Request_Abstract {
 	 * @param string $action
 	 * @param string $params
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	public function __construct($method, $controller, $action, $params = null){ }
 

--- a/Yaf/Request_Abstract.php
+++ b/Yaf/Request_Abstract.php
@@ -33,7 +33,7 @@ abstract class Request_Abstract {
 	 */
 	protected $language;
 	/**
-	 * @var\Yaf\Exception
+	 * @var \Yaf\Exception
 	 */
 	protected $_exception;
 	/**
@@ -163,7 +163,7 @@ abstract class Request_Abstract {
 	/**
 	 * @link http://www.php.net/manual/en/yaf-request-abstract.getexception.php
 	 *
-	 * @return\Yaf\Exception
+	 * @return \Yaf\Exception
 	 */
 	public function getException(){ }
 

--- a/Yaf/Route/Regex.php
+++ b/Yaf/Route/Regex.php
@@ -40,7 +40,7 @@ final class Regex extends \Yaf\Router implements \Yaf\Route_Interface {
 	 * @param array $verify
 	 * @param string $reverse
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	public function __construct($match, array $route, array $map = null, array $verify = null, $reverse = null){ }
 

--- a/Yaf/Route/Rewrite.php
+++ b/Yaf/Route/Rewrite.php
@@ -31,7 +31,7 @@ final class Rewrite extends \Yaf\Router implements \Yaf\Route_Interface {
 	 * @param array $verify
 	 * @param string $reverse
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	public function __construct($match, array $route, array $verify = null, $reverse = null){ }
 

--- a/Yaf/Route/Simple.php
+++ b/Yaf/Route/Simple.php
@@ -34,7 +34,7 @@ final class Simple implements \Yaf\Route_Interface {
 	 * @param string $controller_name
 	 * @param string $action_name
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	public function __construct($module_name, $controller_name, $action_name){ }
 

--- a/Yaf/Route/Supervar.php
+++ b/Yaf/Route/Supervar.php
@@ -18,7 +18,7 @@ final class Supervar implements \Yaf\Route_Interface {
 	 *
 	 * @param string $supervar_name The name of key.
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	public function __construct($supervar_name){ }
 

--- a/Yaf/Route/Supervar.php
+++ b/Yaf/Route/Supervar.php
@@ -12,7 +12,7 @@ final class Supervar implements \Yaf\Route_Interface {
 	protected $_var_name;
 
 	/**
-	 * <p>\Yaf\Route\Supervar is similar to\Yaf\Route_Static, the difference is that \Yaf\Route\Supervar will look for path info in query string, and the parameter supervar_name is the key.</p>
+	 * <p>\Yaf\Route\Supervar is similar to \Yaf\Route_Static, the difference is that \Yaf\Route\Supervar will look for path info in query string, and the parameter supervar_name is the key.</p>
 	 *
 	 * @link http://www.php.net/manual/en/yaf-route-supervar.construct.php
 	 *

--- a/Yaf/Route_Interface.php
+++ b/Yaf/Route_Interface.php
@@ -10,7 +10,7 @@ interface Route_Interface {
 
 	/**
 	 * <p><b>\Yaf\Route_Interface::route()</b> is the only method that a custom route should implement.</p><br/>
-	 * <p>if this method return TRUE, then the route process will be end. otherwise,\Yaf\Router will call next route in the route stack to route request.</p><br/>
+	 * <p>if this method return TRUE, then the route process will be end. otherwise, \Yaf\Router will call next route in the route stack to route request.</p><br/>
 	 * <p>This method would set the route result to the parameter request, by calling \Yaf\Request_Abstract::setControllerName(), \Yaf\Request_Abstract::setActionName() and \Yaf\Request_Abstract::setModuleName().</p><br/>
 	 * <p>This method should also call \Yaf\Request_Abstract::setRouted() to make the request routed at last.</p>
 	 *

--- a/Yaf/Route_Static.php
+++ b/Yaf/Route_Static.php
@@ -2,12 +2,12 @@
 namespace Yaf ;
 
 /**
- * <p>by default,\Yaf\Router only have a <b>\Yaf\Route_Static</b> as its default route.</p>
+ * <p>by default, \Yaf\Router only have a <b>\Yaf\Route_Static</b> as its default route.</p>
  * <br/>
  * <p><b>\Yaf\Route_Static</b> is designed to handle 80% of normal requirements.</p>
  * <br/>
  * <b>Note:</b>
- * <p> it is unnecessary to instance a <b>\Yaf\Route_Static</b>, also unnecessary to add it into\Yaf\Router's routes stack, since there is always be one in\Yaf\Router's routes stack, and always be called at the last time.</p>
+ * <p> it is unnecessary to instance a <b>\Yaf\Route_Static</b>, also unnecessary to add it into \Yaf\Router's routes stack, since there is always be one in \Yaf\Router's routes stack, and always be called at the last time.</p>
  *
  * @link http://www.php.net/manual/en/class.yaf-route-static.php
  *

--- a/Yaf/Router.php
+++ b/Yaf/Router.php
@@ -2,11 +2,11 @@
 namespace Yaf ;
 
 /**
- * <p><b>\Yaf\Router</b> is the standard framework router. Routing is the process of taking a URI endpoint (that part of the URI which comes after the base URI: see \Yaf\Request_Abstract::setBaseUri()) and decomposing it into parameters to determine which module, controller, and action of that controller should receive the request. This values of the module, controller, action and other parameters are packaged into a \Yaf\Request_Abstract object which is then processed by\Yaf\Dispatcher. Routing occurs only once: when the request is initially received and before the first controller is dispatched. \Yaf\Router is designed to allow for mod_rewrite-like functionality using pure PHP structures. It is very loosely based on Ruby on Rails routing and does not require any prior knowledge of webserver URL rewriting</p>
+ * <p><b>\Yaf\Router</b> is the standard framework router. Routing is the process of taking a URI endpoint (that part of the URI which comes after the base URI: see \Yaf\Request_Abstract::setBaseUri()) and decomposing it into parameters to determine which module, controller, and action of that controller should receive the request. This values of the module, controller, action and other parameters are packaged into a \Yaf\Request_Abstract object which is then processed by \Yaf\Dispatcher. Routing occurs only once: when the request is initially received and before the first controller is dispatched. \Yaf\Router is designed to allow for mod_rewrite-like functionality using pure PHP structures. It is very loosely based on Ruby on Rails routing and does not require any prior knowledge of webserver URL rewriting</p>
  * <br/>
  * <b>Default Route</b>
  * <br/>
- * <p><b>\Yaf\Router</b> comes pre-configured with a default route\Yaf\Route_Static, which will match URIs in the shape of controller/action. Additionally, a module name may be specified as the first path element, allowing URIs of the form module/controller/action. Finally, it will also match any additional parameters appended to the URI by default - controller/action/var1/value1/var2/value2.</p>
+ * <p><b>\Yaf\Router</b> comes pre-configured with a default route \Yaf\Route_Static, which will match URIs in the shape of controller/action. Additionally, a module name may be specified as the first path element, allowing URIs of the form module/controller/action. Finally, it will also match any additional parameters appended to the URI by default - controller/action/var1/value1/var2/value2.</p>
  * <br/>
  * <b>Note:</b>
  * <p>Module name must be defined in config, considering application.module="Index,Foo,Bar", in this case, only index, foo and bar can be considered as a module name. if doesn't config, there is only one module named "Index".</p>
@@ -31,7 +31,7 @@ class Router {
 	public function __construct(){ }
 
 	/**
-	 * <p>by default, \Yaf\Router using a\Yaf\Route_Static as its default route. you can add new routes into router's route stack by calling this method.</p>
+	 * <p>by default, \Yaf\Router using a \Yaf\Route_Static as its default route. you can add new routes into router's route stack by calling this method.</p>
 	 * <br/>
 	 * <p>the newer route will be called before the older(route stack), and if the newer router return TRUE, the router process will be end. otherwise, the older one will be called.</p>
 	 *

--- a/Yaf/View/Simple.php
+++ b/Yaf/View/Simple.php
@@ -38,7 +38,7 @@ class Simple implements \Yaf\View_Interface {
 	 * so comes a option named "short_tag",  you can switch this off
 	 * to prevent use short_tag in template.
 	 *
-	 * @throws\Yaf\Exception\TypeError
+	 * @throws \Yaf\Exception\TypeError
 	 */
 	final public function __construct($template_dir, array $options = null){ }
 
@@ -66,7 +66,7 @@ class Simple implements \Yaf\View_Interface {
 	 * @param string $tpl
 	 * @param array $tpl_vars
 	 *
-	 * @throws\Yaf\Exception\LoadFailed\View
+	 * @throws \Yaf\Exception\LoadFailed\View
 	 *
 	 * @return string|void
 	 */
@@ -80,7 +80,7 @@ class Simple implements \Yaf\View_Interface {
 	 * @param string $tpl
 	 * @param array $tpl_vars
 	 *
-	 * @throws\Yaf\Exception\LoadFailed\View
+	 * @throws \Yaf\Exception\LoadFailed\View
 	 *
 	 * @return bool
 	 */

--- a/Yaf/View_Interface.php
+++ b/Yaf/View_Interface.php
@@ -2,7 +2,7 @@
 namespace Yaf ;
 
 /**
- * Yaf provides a ability for developers to use custom view engine instead of build-in engine which is\Yaf\View\Simple. There is a example to explain how to do this, please see\Yaf\Dispatcher::setView()
+ * Yaf provides a ability for developers to use custom view engine instead of build-in engine which is \Yaf\View\Simple. There is a example to explain how to do this, please see \Yaf\Dispatcher::setView()
  *
  * @link http://www.php.net/manual/en/class.yaf-view-interface.php
  */
@@ -49,11 +49,11 @@ interface View_Interface {
 	function render($tpl, array $tpl_vars = null);
 
 	/**
-	 * Set the templates base directory, this is usually called by\Yaf\Dispatcher
+	 * Set the templates base directory, this is usually called by \Yaf\Dispatcher
 	 *
 	 * @link http://www.php.net/manual/en/yaf-view-interface.setscriptpath.php
 	 *
-	 * @param string $template_dir An absolute path to the template directory, by default,\Yaf\Dispatcher use application.directory . "/views" as this parameter.
+	 * @param string $template_dir An absolute path to the template directory, by default, \Yaf\Dispatcher use application.directory . "/views" as this parameter.
 	 */
 	function setScriptPath($template_dir);
 }

--- a/generate_namespaces.php
+++ b/generate_namespaces.php
@@ -165,7 +165,7 @@ foreach($class_hash as $key => &$value)
 {
 
 	$trimmed = trim(get_namespaced_class_name($key, CD, NSD));
-	$value = ($trimmed{0}=="|" ? '|'.NSD.substr($trimmed,1): NSD. $trimmed);
+	$value = ($trimmed{0}=="|" ? '|'.NSD.substr($trimmed,1): ' '.NSD. $trimmed);
 }
 $class_hash = array_reverse($class_hash);
 $class_hash_keys = array_keys($class_hash);


### PR DESCRIPTION
The problem is caused by a bug in generate_namespace.php. It search the word leading with ` Yaf_` and convert it into ` Yaf\`, and trim to `Yaf\` and add root namespace delimiter as `\Yaf\`, but missing the original space before the whole class name.

I fixed that issue and regenerated all the files.